### PR TITLE
Fix Python 3 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
   - ANSIBLE_VERSION=latest
   # run against minimal required version
   - ANSIBLE_VERSION=2.5.*
-  - ANSIBLE_VERSION=2.6.*
-  - ANSIBLE_VERSION=2.7.*
 
 # Use the new container infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
   # run against latest version
   - ANSIBLE_VERSION=latest
   # run against minimal required version
-  - ANSIBLE_VERSION=2.4.*
+  - ANSIBLE_VERSION=2.5.*
+  - ANSIBLE_VERSION=2.6.*
+  - ANSIBLE_VERSION=2.7.*
 
 # Use the new container infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 ---
 language: python
 cache: pip
-python: "2.7"
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 env:
   # run against latest version
   - ANSIBLE_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   # run against latest version
   - ANSIBLE_VERSION=latest
   # run against minimal required version
-  - ANSIBLE_VERSION=2.2.*
+  - ANSIBLE_VERSION=2.4.*
 
 # Use the new container infrastructure
 sudo: false

--- a/action_plugins/conga_facts.py
+++ b/action_plugins/conga_facts.py
@@ -195,7 +195,7 @@ class ActionModule(ActionBase):
 
         # filter matching roles by variant name
         if ansible_variant:
-            matching_roles = filter(lambda role: ansible_variant in role.get("variants", ""), matching_roles)
+            matching_roles = list(filter(lambda role: ansible_variant in role.get("variants", ""), matching_roles))
 
         # warn if the matched role is not unique
         if len(matching_roles) > 1:

--- a/action_plugins/conga_facts.py
+++ b/action_plugins/conga_facts.py
@@ -191,7 +191,7 @@ class ActionModule(ActionBase):
         ansible_role = ansible_role.replace("_", "-")
 
         # filter by role name
-        matching_roles = filter(lambda role: role.get("role", "") == ansible_role, roles)
+        matching_roles = list(filter(lambda role: role.get("role", "") == ansible_role, roles))
 
         # filter matching roles by variant name
         if ansible_variant:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
 
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
 
   platforms:
   - name: Ubuntu

--- a/tests/test_conga_facts.py
+++ b/tests/test_conga_facts.py
@@ -32,7 +32,7 @@ class MockModule(ActionModule):
 
     def run(self, task_vars=TASK_VARS):
         with patch('action_plugins.conga_facts.open') as mock_open:
-            mock_open.return_value = MagicMock(spec=file)
+            mock_open.return_value = MagicMock()
             return super(MockModule, self).run(None, task_vars)
 
     def get_facts(self, task_vars=TASK_VARS):


### PR DESCRIPTION
In Python 3, a filter result is no longer of type "list", therefore this change is needed.