### PR TITLE
Allow to set conga_basedir on a play level

### DIFF
--- a/action_plugins/conga_facts.py
+++ b/action_plugins/conga_facts.py
@@ -159,6 +159,12 @@ class ActionModule(ActionBase):
     def conga_basedir(self):
         # Get CONGA basedir from the host vars of the host CONGA was executed on
         # Currently this has to be localhost, since we need access to the generated files
+
+        # Check if conga_basedir was defined explicitly in play variables or via set_facts.
+        conga_basedir = self._get_arg_or_var("conga_basedir", None, False)
+        if conga_basedir:
+            return conga_basedir
+
         conga_host = self._get_arg_or_var('conga_host', 'localhost')
         conga_basedir = self._task_vars['hostvars'].get(conga_host, {}).get('conga_basedir')
         if not conga_basedir:


### PR DESCRIPTION
`conga_basedir` always gets retrieved by checking the host variables. In my specific example, `conga_basedir` has to be set on a play level, and this was not honoured without this change. It's set in group_vars/all (like a fallback), and this was overriding anything I wanted to set in my playbook. There are 2 CONGA directories in my specific project.

Setting it on the command line via `-e conga_basedir=foo` works though, and I don't really get why. However, on this branch, my play-level variable also gets used as expected